### PR TITLE
Update Guzzle to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ovh/ovh",
     "description": "Wrapper for OVH APIs",
     "require": {
-        "guzzlehttp/guzzle": "4.*"
+        "guzzlehttp/guzzle": ">=4.0,<6.0"
     },
     "version": "0.1",
     "minimum-stability": "RC",


### PR DESCRIPTION
To allow using the SDK on project using the latest stable Guzzle version.
