### PR TITLE
Fix composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
     "require": {
         "guzzlehttp/guzzle": ">=4.0,<6.0"
     },
-    "version": "1.1.0",
-    "minimum-stability": "RC",
     "authors": [
         {
             "name": "Vincent Cassé"


### PR DESCRIPTION
Currently, the package is not installable through Composer in stable version. This PR fix that and let Composer rely on Git tags (more convenient).
