### PR TITLE
Add Symfony bundle reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Then, you can install OVH APIs wrapper and dependencies with:
 This will install ``ovh/ovh`` to ``./vendor``, along with other dependencies
 including ``autoload.php``.
 
+Symfony integration
+-------------------
+
+[Les-Tilleuls.coop](http://les-tilleuls.coop) provides a bundle integrating this SDK with
+[the Symfony framework](http://symfony.com): [CoopTilleulsOvhBundle](https://github.com/coopTilleuls/CoopTilleulsOvhBundle).
+
 How to login as a user?
 -----------------------
 


### PR DESCRIPTION
We ([Les-Tilleuls.coop](http://les-tilleuls.coop)) created [a bundle](https://github.com/coopTilleuls/CoopTilleulsOvhBundle) exposing the OVH SDK as a service for the Symfony framework. It's a convenient way to install and use the SDK with Symfony.

This PR references the bundle in `README.md`.