### PR TITLE
Add the package license for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "ovh/ovh",
     "description": "Wrapper for OVH APIs",
+    "license": "BSD-3-Clause",
     "require": {
         "guzzlehttp/guzzle": ">=4.0,<6.0"
     },


### PR DESCRIPTION
this allows the license to be known on Packagist instead of marking it as unknown license: https://packagist.org/packages/ovh/ovh

The LICENSE file looks like the text of the MIT license, which is why I did the update this way. If it is not actually the MIT license but a different one, please provide the actual license code.