### PR TITLE
Improve the PHPUnit setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 vendor
 composer.lock
 composer.phar
+/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr-4": {"Ovh\\": "src/"}
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*",
+        "phpunit/phpunit": "4.*",
         "phpdocumentor/phpdocumentor": "2.*",
         "squizlabs/php_codesniffer": "1.*"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,5 +10,10 @@
         <env name="APP_KEY" value=""/>
         <env name="APP_SECRET" value=""/>
         <env name="CONSUMER" value=""/>
-	</php>
+    </php>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
- allow maintained versions of PHPUnit 4 instead of the old 4.0 only
- add the code coverage configuration to cover only the library code and not all tests and vendors as well
- move the configuration to phpunit.xml.dist to follow PHPUnit best practices