### PR TITLE
Update to Guzzle 6.0 and add 100% code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - hhvm
   - 5.6
   - 5.5
-  - 5.4
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.4
 
 before_script:
-  - composer install --dev
+  - composer self-update
+  - composer install
 
 script: phpunit tests/ApiTest.php

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Wrapper for OVH APIs",
     "license": "BSD-3-Clause",
     "require": {
-        "guzzlehttp/guzzle": ">=4.0,<6.0"
+        "guzzlehttp/guzzle": "^6.0"
     },
     "authors": [
         {

--- a/src/Api.php
+++ b/src/Api.php
@@ -30,8 +30,9 @@
 
 namespace Ovh;
 
-use GuzzleHttp\Client as GClient;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 
 /**
  * Wrapper to manage login and exchanges with simpliest Ovh API
@@ -41,74 +42,90 @@ use GuzzleHttp\Stream\Stream;
  * Http connections use guzzle http client api and result of request are
  * object from this http wrapper
  *
- * @package Ovh
+ * @package  Ovh
  * @category Ovh
- * @author Vincent Cassé <vincent.casse@ovh.net>
+ * @author   Vincent Cassé <vincent.casse@ovh.net>
+ * @author   Thierry Goettelmann <thierry@byscripts.info>
  */
 class Api
 {
-
     /**
      * Url to communicate with Ovh API
+     *
+     * @var array
      */
-    private $endpoints = array(
-        'ovh-eu' => 'https://api.ovh.com/1.0',
-        'ovh-ca' => 'https://ca.api.ovh.com/1.0',
-        'kimsufi-eu' => 'https://eu.api.kimsufi.com/1.0',
-        'kimsufi-ca' => 'https://ca.api.kimsufi.com/1.0',
+    private $endpoints = [
+        'ovh-eu'        => 'https://api.ovh.com/1.0',
+        'ovh-ca'        => 'https://ca.api.ovh.com/1.0',
+        'kimsufi-eu'    => 'https://eu.api.kimsufi.com/1.0',
+        'kimsufi-ca'    => 'https://ca.api.kimsufi.com/1.0',
         'soyoustart-eu' => 'https://eu.api.soyoustart.com/1.0',
         'soyoustart-ca' => 'https://ca.api.soyoustart.com/1.0',
-        'runabove-ca' => 'https://api.runabove.com/1.0');
+        'runabove-ca'   => 'https://api.runabove.com/1.0',
+    ];
 
     /**
      * Contain endpoint selected to choose API
+     *
+     * @var string
      */
     private $endpoint = null;
 
     /**
      * Contain key of the current application
+     *
+     * @var string
      */
     private $application_key = null;
 
     /**
      * Contain secret of the current application
+     *
+     * @var string
      */
     private $application_secret = null;
 
     /**
      * Contain consumer key of the current application
+     *
+     * @var string
      */
     private $consumer_key = null;
 
     /**
      * Contain delta between local timestamp and api server timestamp
+     *
+     * @var string
      */
     private $time_delta = null;
 
     /**
      * Contain http client connection
+     *
+     * @var Client
      */
     private $http_client = null;
 
     /**
      * Construct a new wrapper instance
      *
-     * @param $application_key key of your application.
-     * For OVH APIs, you can create a application's credentials on https://api.ovh.com/createApp/
-     * @param $application_secret secret of your application.
-     * @param $api_endpoint name of api selected
-     * @param $consumer_key If you have already a consumer key, this parameter prevent to do a
-     * new authentication
-     * @param $http_client instance of http client
+     * @param string $application_key    key of your application.
+     *                                   For OVH APIs, you can create a application's credentials on
+     *                                   https://api.ovh.com/createApp/
+     * @param string $application_secret secret of your application.
+     * @param string $api_endpoint       name of api selected
+     * @param string $consumer_key       If you have already a consumer key, this parameter prevent to do a
+     *                                   new authentication
+     * @param Client $http_client        instance of http client
      *
-     * @throws InvalidParameterException if one parameter is missing or with bad value
+     * @throws Exceptions\InvalidParameterException if one parameter is missing or with bad value
      */
     public function __construct(
         $application_key,
         $application_secret,
         $api_endpoint,
         $consumer_key = null,
-        GClient $http_client = null
+        Client $http_client = null
     ) {
         if (!isset($application_key)) {
             throw new Exceptions\InvalidParameterException("Application key parameter is empty");
@@ -127,29 +144,31 @@ class Api
         }
 
         if (!isset($http_client)) {
-            $http_client = new GClient();
+            $http_client = new Client();
         }
 
-        $this->application_key = $application_key;
-        $this->endpoint = $this->endpoints[$api_endpoint];
+        $this->application_key    = $application_key;
+        $this->endpoint           = $this->endpoints[$api_endpoint];
         $this->application_secret = $application_secret;
-        $this->http_client = $http_client;
-        $this->consumer_key = $consumer_key;
-        $this->time_delta = null;
+        $this->http_client        = $http_client;
+        $this->consumer_key       = $consumer_key;
+        $this->time_delta         = null;
     }
 
     /**
      * Calculate time delta between local machine and API's server
      *
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @return int
      */
     private function calculateTimeDelta()
     {
         if (!isset($this->time_delta)) {
-            $response = $this->http_client->get($this->endpoint . "/auth/time");
-            $serverTimestamp = (int) (String) $response->getBody();
-            $this->time_delta = $serverTimestamp - (int) \time();
+            $response         = $this->http_client->get($this->endpoint . "/auth/time");
+            $serverTimestamp  = (int)(String)$response->getBody();
+            $this->time_delta = $serverTimestamp - (int)\time();
         }
+
         return $this->time_delta;
     }
 
@@ -157,16 +176,17 @@ class Api
      * Request a consumer key from the API and the validation link to
      * authorize user to validate this consumer key
      *
-     * @param $accessRules list of rules your application need.
-     * @param $redirection url to redirect on your website after authentication
+     * @param array  $accessRules list of rules your application need.
+     * @param string $redirection url to redirect on your website after authentication
      *
+     * @return mixed
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
     public function requestCredentials(
-        $accessRules,
+        array $accessRules,
         $redirection = null
     ) {
-        $parameters = new \StdClass();
+        $parameters              = new \StdClass();
         $parameters->accessRules = $accessRules;
         $parameters->redirection = $redirection;
 
@@ -179,6 +199,7 @@ class Api
         );
 
         $this->consumer_key = $response["consumerKey"];
+
         return $response;
     }
 
@@ -186,42 +207,44 @@ class Api
      * This is the main method of this wrapper. It will
      * sign a given query and return its result.
      *
-     * @param $method HTTP method of request (GET,POST,PUT,DELETE)
-     * @param $path relative url of API request
-     * @param $content body of the request
-     * @param $is_authenticated if the request use authentication
+     * @param string               $method           HTTP method of request (GET,POST,PUT,DELETE)
+     * @param string               $path             relative url of API request
+     * @param \stdClass|array|null $content          body of the request
+     * @param bool                 $is_authenticated if the request use authentication
      *
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    private function rawCall(
-        $method,
-        $path,
-        $content = null,
-        $is_authenticated = true
-    ) {
-        $url = $this->endpoint . $path;
-
-        $request = $this->http_client->createRequest(
-            $method,
-            $url
-        );
+    private function rawCall($method, $path, $content = null, $is_authenticated = true)
+    {
+        $url     = $this->endpoint . $path;
+        $request = new Request($method, $url);
 
         if (isset($content) && $method == 'GET') {
-            $query = $request->getQuery();
-            foreach ($content as $key => $value) {
-                $query->set($key, $value);
-            }
-            $url .= '?'.$query;
-            $body = "";
+
+            $queryString = $request->getUri()->getQuery();
+
+            $query = false !== strpos($queryString, '&')
+                ? explode('&', $queryString)
+                : [];
+
+            $query = array_merge($query, (array)$content);
+            $query = \GuzzleHttp\Psr7\build_query($query);
+
+            $request = $request->withUri($request->getUri()->withQuery($query));
+            $body    = "";
         } elseif (isset($content)) {
             $body = json_encode($content);
-            $request->setBody(Stream::factory($body));
+
+            $request->getBody()->write($body);
         } else {
             $body = "";
         }
 
-        $request->setHeader('Content-Type', 'application/json; charset=utf-8');
-        $request->setHeader('X-Ovh-Application', $this->application_key);
+        $headers = [
+            'Content-Type'      => 'application/json; charset=utf-8',
+            'X-Ovh-Application' => $this->application_key,
+        ];
 
         if ($is_authenticated) {
             if (!isset($this->time_delta)) {
@@ -229,75 +252,76 @@ class Api
             }
             $now = time() + $this->time_delta;
 
-            $request->setHeader('X-Ovh-Timestamp', $now);
+            $headers['X-Ovh-Timestamp'] = $now;
 
             if (isset($this->consumer_key)) {
-                $toSign =  $this->application_secret.'+'.$this->consumer_key.'+'.$method.'+'.$url.'+'.$body.'+'.$now;
-                $signature = '$1$' . sha1($toSign);
-                $request->setHeader('X-Ovh-Consumer', $this->consumer_key);
-                $request->setHeader('X-Ovh-Signature', $signature);
+                $toSign                     = $this->application_secret . '+' . $this->consumer_key . '+' . $method
+                    . '+' . $url . '+' . $body . '+' . $now;
+                $signature                  = '$1$' . sha1($toSign);
+                $headers['X-Ovh-Consumer']  = $this->consumer_key;
+                $headers['X-Ovh-Signature'] = $signature;
             }
         }
-        return $this->http_client->send($request)->json();
+
+        /** @var Response $response */
+        $response = $this->http_client->send($request, ['headers' => $headers]);
+
+        return json_decode($response->getBody(), true);
     }
 
     /**
      * Wrap call to Ovh APIs for GET requests
      *
-     * @param $path path ask inside api
-     * @param $content content to send inside body of request
+     * @param string $path    path ask inside api
+     * @param array  $content content to send inside body of request
      *
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    public function get(
-        $path,
-        $content = null
-    ) {
+    public function get($path, $content = null)
+    {
         return $this->rawCall("GET", $path, $content);
     }
 
     /**
      * Wrap call to Ovh APIs for POST requests
      *
-     * @param $path path ask inside api
-     * @param $content content to send inside body of request
+     * @param string $path    path ask inside api
+     * @param array  $content content to send inside body of request
      *
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    public function post(
-        $path,
-        $content = null
-    ) {
+    public function post($path, $content = null)
+    {
         return $this->rawCall("POST", $path, $content);
     }
 
     /**
      * Wrap call to Ovh APIs for PUT requests
      *
-     * @param $path path ask inside api
-     * @param $content content to send inside body of request
+     * @param string $path    path ask inside api
+     * @param array  $content content to send inside body of request
      *
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    public function put(
-        $path,
-        $content
-    ) {
+    public function put($path, $content)
+    {
         return $this->rawCall("PUT", $path, $content);
     }
 
     /**
      * Wrap call to Ovh APIs for DELETE requests
      *
-     * @param $path path ask inside api
-     * @param $content content to send inside body of request
+     * @param string $path    path ask inside api
+     * @param array  $content content to send inside body of request
      *
+     * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    public function delete(
-        $path,
-        $content = null
-    ) {
+    public function delete($path, $content = null)
+    {
         return $this->rawCall("DELETE", $path, $content);
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -27,140 +27,259 @@
 
 namespace Ovh\tests;
 
-use Ovh\Api;
-
 use GuzzleHttp\Client;
-use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Ovh\Api;
 
 /**
  * Test Api class
  *
- * @package Ovh
+ * @package  Ovh
  * @category Ovh
- * @author Vincent Cassé <vincent.casse@ovh.net>
+ * @author   Vincent Cassé <vincent.casse@ovh.net>
+ * @author   Thierry Goettelmann <thierry@byscripts.info>
  */
-class ApiTest extends \PHPUnit_Framework_TestCase {
+class ApiTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
 
-	/**
-	 * Define id to create object
-	 */
-	protected function setUp()
+    /**
+     * @var string
+     */
+    private $application_key;
+
+    /**
+     * @var string
+     */
+    private $consumer_key;
+
+    /**
+     * @var string
+     */
+    private $endpoint;
+
+    /**
+     * @var string
+     */
+    private $application_secret;
+
+    /**
+     * Define id to create object
+     */
+    protected function setUp()
     {
-		$this->application_key = 'app_key';
-		$this->application_secret = 'app_secret';
-		$this->consumer_key = 'consumer';
-		$this->endpoint = 'ovh-eu';
+        $this->application_key    = 'app_key';
+        $this->application_secret = 'app_secret';
+        $this->consumer_key       = 'consumer';
+        $this->endpoint           = 'ovh-eu';
 
         $this->client = new Client();
     }
 
     /**
      * Get private and protected method to unit test it
+     *
+     * @param string $name
+     *
+     * @return \ReflectionMethod
      */
     protected static function getPrivateMethod($name)
     {
-        $class = new \ReflectionClass('Ovh\Api');
+        $class  = new \ReflectionClass('Ovh\Api');
         $method = $class->getMethod($name);
         $method->setAccessible(true);
+
         return $method;
     }
 
+    /**
+     * Get private and protected property to unit test it
+     *
+     * @param string $name
+     *
+     * @return \ReflectionProperty
+     */
     protected static function getPrivateProperty($name)
     {
-        $class = new \ReflectionClass('Ovh\Api');
+        $class    = new \ReflectionClass('Ovh\Api');
         $property = $class->getProperty($name);
         $property->setAccessible(true);
+
         return $property;
     }
 
-	/**
-	 * Test the compute of time delta
-	 */
-	public function testTimeDeltaCompute()
-	{
-		$delay = 10;
-        $mock = new Mock([
-        	"HTTP/1.1 200 OK\r\n\r\n". (time()-$delay),
-        ]);
-		$this->client->getEmitter()->attach($mock);
+    /**
+     * Test missing $application_key
+     */
+    public function testMissingApplicationKey()
+    {
+        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Application key');
+        new Api(null, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+    }
 
-		$invoker = self::getPrivateMethod('calculateTimeDelta');
-		$property = self::getPrivateProperty('time_delta');
-		$api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
-		$invoker->invokeArgs($api, array()) ;
+    /**
+     * Test missing $application_secret
+     */
+    public function testMissingApplicationSecret()
+    {
+        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Application secret');
+        new Api($this->application_key, null, $this->endpoint, $this->consumer_key, $this->client);
+    }
 
-		$time_delta = $property->getValue($api);
-		$this->assertNotNull($time_delta);
-		$this->assertEquals($time_delta, $delay * -1 );
-	}
+    /**
+     * Test missing $api_endpoint
+     */
+    public function testMissingApiEndpoint()
+    {
+        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Endpoint');
+        new Api($this->application_key, $this->application_secret, null, $this->consumer_key, $this->client);
+    }
 
-	/**
-	 * Test if consumer key is replaced
-	 */
-	public function testIfConsumerKeyIsReplace()
-	{
-		$delay = 10;
-        $mock = new Mock([
-        	"HTTP/1.1 200 OK\r\n\r\n". '{"validationUrl":"https://api.ovh.com/login/?credentialToken=token","consumerKey":"consumer_remote","state":"pendingValidation"}'
-        ]);
-		$this->client->getEmitter()->attach($mock);
+    /**
+     * Test bad $api_endpoint
+     */
+    public function testBadApiEndpoint()
+    {
+        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Unknown');
+        new Api($this->application_key, $this->application_secret, 'i_am_invalid', $this->consumer_key, $this->client);
+    }
 
-		$property = self::getPrivateProperty('consumer_key');
-		$api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
-		$accessRules = array( json_decode(' { "method": "GET", "path": "/*" } ') );
+    /**
+     * Test creating Client if none is provided
+     */
+    public function testClientCreation()
+    {
+        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key);
 
-		$credentials = $api->requestCredentials($accessRules);
-		$consumer_key = $property->getValue($api);
+        $this->assertInstanceOf('\\GuzzleHttp\\Client', $api->getHttpClient());
+    }
 
-		$this->assertEquals( $consumer_key , $credentials["consumerKey"]);
-		$this->assertNotEquals( $consumer_key, $this->consumer_key );
-	}
+    /**
+     * Test the compute of time delta
+     */
+    public function testTimeDeltaCompute()
+    {
+        $delay = 10;
 
-	/**
-	 * Test invalid applicationKey
-	 */
-	public function testInvalidApplicationKey()
-	{
-		$this->setExpectedException(
-          '\GuzzleHttp\Exception\ClientException'
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapResponse(function (Response $response) {
+
+            $body = $response->getBody();
+            $body->write(time() - 10);
+
+            return $response
+                ->withStatus(200)
+                ->withBody($body);
+        }));
+
+        $invoker  = self::getPrivateMethod('calculateTimeDelta');
+        $property = self::getPrivateProperty('time_delta');
+
+        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+        $invoker->invokeArgs($api, []);
+
+        $time_delta = $property->getValue($api);
+        $this->assertNotNull($time_delta);
+        $this->assertEquals($time_delta, $delay * -1);
+    }
+
+    /**
+     * Test if consumer key is replaced
+     */
+    public function testIfConsumerKeyIsReplace()
+    {
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapResponse(function (Response $response) {
+
+            $body = $response->getBody();
+            $body->write('{"validationUrl":"https://api.ovh.com/login/?credentialToken=token","consumerKey":"consumer_remote","state":"pendingValidation"}');
+
+            return $response
+                ->withStatus(200)
+                ->withBody($body);
+        }));
+
+        $property = self::getPrivateProperty('consumer_key');
+
+        $api         = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+        $accessRules = [json_decode(' { "method": "GET", "path": "/*" } ')];
+
+        $credentials = $api->requestCredentials($accessRules);
+
+        $consumer_key = $property->getValue($api);
+
+        $this->assertEquals($consumer_key, $credentials["consumerKey"]);
+        $this->assertNotEquals($consumer_key, $this->consumer_key);
+    }
+
+    /**
+     * Test invalid applicationKey
+     */
+    public function testInvalidApplicationKey()
+    {
+        $this->setExpectedException(
+            '\GuzzleHttp\Exception\ClientException'
         );
 
-		$delay = 10;
-        $mock = new Mock([
-        	"HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 37\r\n\r\n{\"message\":\"Invalid application key\"}"
-        ]);
-		$this->client->getEmitter()->attach($mock);
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
-		$property = self::getPrivateProperty('consumer_key');
-		$api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
-		$accessRules = array( json_decode(' { "method": "GET", "path": "/*" } ') );
+            $body = $response->getBody();
+            $body->write('{\"message\":\"Invalid application key\"}');
 
-		$credentials = $api->requestCredentials($accessRules);
-		$consumer_key = $property->getValue($api);
+            return $response
+                ->withStatus(401, 'POUET')
+                ->withHeader('Content-Type', 'application/json; charset=utf-8')
+                ->withHeader('Content-Length', 37)
+                ->withBody($body);
+        }));
 
-		$this->assertEquals( $consumer_key , $credentials["consumerKey"]);
-		$this->assertNotEquals( $consumer_key, $this->consumer_key );
-	}
+        $property    = self::getPrivateProperty('consumer_key');
+        $api         = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+        $accessRules = [json_decode(' { "method": "GET", "path": "/*" } ')];
 
-	/**
-	 * Test invalid rights
-	 */
-	public function testInvalidRight()
-	{
-		$this->setExpectedException(
-          '\GuzzleHttp\Exception\ClientException'
+        $credentials  = $api->requestCredentials($accessRules);
+        $consumer_key = $property->getValue($api);
+
+        $this->assertEquals($consumer_key, $credentials["consumerKey"]);
+        $this->assertNotEquals($consumer_key, $this->consumer_key);
+    }
+
+    /**
+     * Test invalid rights
+     */
+    public function testInvalidRight()
+    {
+        $this->setExpectedException(
+            '\GuzzleHttp\Exception\ClientException'
         );
 
-		$delay = 10;
-        $mock = new Mock([
-        	"HTTP/1.1 403 Forbidden\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 37\r\n\r\n{\"message\":\"Invalid credentials\"}"
-        ]);
-		$this->client->getEmitter()->attach($mock);
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
-		$api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+            $body = $response->getBody();
+            $body->write('{\"message\":\"Invalid credentials\"}');
 
-		$invoker = self::getPrivateMethod('rawCall');
-		$invoker->invokeArgs($api, array('GET', '/me')) ;
-	}
+            return $response
+                ->withStatus(403)
+                ->withHeader('Content-Type', 'application/json; charset=utf-8')
+                ->withHeader('Content-Length', 37)
+                ->withBody($body);
+        }));
+
+        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+
+        $invoker = self::getPrivateMethod('rawCall');
+        $invoker->invokeArgs($api, ['GET', '/me']);
+    }
+
+    public function testGetConsumerKey()
+    {
+        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+        $this->assertEquals($this->consumer_key, $api->getConsumerKey());
+    }
 }
-


### PR DESCRIPTION
I rewritten the API to support the new Guzzle 6.0
I also added 100% code coverage and completed the PhpDoc and type hintings

No method name has changed, only the to request with Guzzle.

Since Guzzle 6.0 is clearly not complatible with <6.0, I think this PR should be on a new dev branch (and a new major version )