### PR TITLE
Add content from QueryString into  to build signature

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -232,7 +232,8 @@ class Api
             $query = array_merge($query, (array)$content);
             $query = \GuzzleHttp\Psr7\build_query($query);
 
-            $request = $request->withUri($request->getUri()->withQuery($query));
+            $url     = $request->getUri()->withQuery($query);
+            $request = $request->withUri($url);
             $body    = "";
         } elseif (isset($content)) {
             $body = json_encode($content);

--- a/tests/ApiFunctionalTest.php
+++ b/tests/ApiFunctionalTest.php
@@ -242,4 +242,12 @@ class ApiFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $this->api->get('/me/accessRestriction/ip', ['foo' => 'bar']);
     }
+
+    /**
+     * Test Api::get, should build valide signature
+     */
+    public function testApiGetWithQueryString()
+    {
+        $this->api->get('/me/api/credential', ['status' => 'pendingValidation']);
+    }
 }


### PR DESCRIPTION
fix invalid signature introduce by skipping query string parameter inside request content
Signed-off-by: Adrien Bensaibi <adrien.bensaibi@corp.ovh.com>