### PR TITLE
fix: incorrect query when passed from url and not from content

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -226,7 +226,7 @@ class Api
             $query_string = $request->getUri()->getQuery();
 
             $query = array();
-            if ($query_string != '') {
+            if (!empty($query_string)) {
                 $queries = explode('&', $query_string);
                 foreach($queries as $element) {
                     $key_value_query = explode('=', $element, 2);

--- a/src/Api.php
+++ b/src/Api.php
@@ -223,11 +223,16 @@ class Api
 
         if (isset($content) && $method == 'GET') {
 
-            $queryString = $request->getUri()->getQuery();
+            $query_string = $request->getUri()->getQuery();
 
-            $query = false !== strpos($queryString, '&')
-                ? explode('&', $queryString)
-                : [];
+            $query = array();
+            if ($query_string != '') {
+                $queries = explode('&', $query_string);
+                foreach($queries as $element) {
+                    $key_value_query = explode('=', $element, 2);
+                    $query[$key_value_query[0]] = $key_value_query[1];
+                }
+            }
 
             $query = array_merge($query, (array)$content);
             $query = \GuzzleHttp\Psr7\build_query($query);

--- a/src/Api.php
+++ b/src/Api.php
@@ -235,6 +235,20 @@ class Api
             }
 
             $query = array_merge($query, (array)$content);
+
+            // rewrite query args to properly dump true/false parameters
+            foreach($query as $key => $value)
+            {
+                if ($value === false)
+                {
+                    $query[$key] = "false";
+                }
+                elseif ($value === true)
+                {
+                    $query[$key] = "true";
+                }
+            }
+
             $query = \GuzzleHttp\Psr7\build_query($query);
 
             $url     = $request->getUri()->withQuery($query);

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -364,7 +364,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         //}));
 
         $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
-        $api->get('/me/api/credential', ['dryRun' => true, 'noDryRun' => false]);
+        $api->get('/me/api/credential', ['dryRun' => true, 'notDryRun' => false]);
     }
 
 }


### PR DESCRIPTION
Problem occured when passing arguments in the path.

Example: 
```$ovh->get("/me/api/credentials?status=refused", array("applicationId" => $app_id);```
status=refused wasn't taken in count

+ fixed some problems due to ambiguous explode
