### PR TITLE
add bump-version helper

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Usage: ./scripts/bump-version.sh <new.version.number>
+#
+
+PCRE_MATCH_VERSION="[0-9]+\.[0-9]+\.[0-9]+"
+PCRE_MATCH_VERSION_BOUNDS="(^|[- v/'\"])${PCRE_MATCH_VERSION}([- /'\"]|$)"
+VERSION="$1"
+
+if ! echo "$VERSION" | grep -Pq "${PCRE_MATCH_VERSION}"; then
+    echo "Usage: ./scripts/bump-version.sh <new.version.number>"
+    echo "    <new.version.number> must be a valid 3 digit version number"
+    echo "    Make sure to double check 'git diff' before commiting anything you'll regret on master"
+    exit 1
+fi
+
+# Edit text files matching the PCRE, do *not* patch .git folder
+grep -PIrl "${PCRE_MATCH_VERSION_BOUNDS}" $(ls) | xargs sed -ir "s/${PCRE_MATCH_VERSION_BOUNDS}/"'\1'"${VERSION}"'\2/g'
+


### PR DESCRIPTION
Following discussion in #37, here is a quick and dirty "bump version" helper. It will replace all strings that looks like a version number by the new version number. Only matches 3 digit based versions. No letters.

Use this carefully. It may (read: will) require fine tuning.