### PR TITLE
Remove dependency on Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,10 @@
     "description": "Wrapper for OVH APIs",
     "license": "BSD-3-Clause",
     "require": {
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/psr7": "~1.2",
+        "php-http/httplug": "^1.0",
+        "php-http/client-implementation": "^1.0",
+        "php-http/discovery": "^0.8"
     },
     "autoload": {
         "psr-4": {"Ovh\\": "src/"}
@@ -12,6 +15,7 @@
         "phpunit/phpunit": "4.*",
         "phpdocumentor/phpdocumentor": "2.*",
         "squizlabs/php_codesniffer": "2.*",
-        "phing/phing": "^2.14"
+        "phing/phing": "^2.14",
+        "php-http/guzzle6-adapter": "^1.0"
     }
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -30,6 +30,8 @@
 
 namespace Ovh;
 
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -276,15 +278,13 @@ class Api
             }
         }
 
-        $request = new Request(
+        /** @var ResponseInterface $response */
+        return $this->sendRequest(new Request(
             $method,
             $uri,
             $headers,
             $body
-        );
-
-        /** @var Response $response */
-        return $this->getHttpClient()->sendRequest($request);
+        ));
     }
 
     /**
@@ -377,5 +377,15 @@ class Api
     public function getHttpClient()
     {
         return $this->http_client;
+    }
+
+    /**
+     * Send the Request through the HttpClient
+     * @param  RequestInterface $request
+     * @return ResponseInterface
+     */
+    private function sendRequest(RequestInterface $request)
+    {
+        return $this->getHttpClient()->sendRequest($request);
     }
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -30,9 +30,11 @@
 
 namespace Ovh;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 
 /**
  * Wrapper to manage login and exchanges with simpliest Ovh API
@@ -100,7 +102,7 @@ class Api
     /**
      * Contain http client connection
      *
-     * @var Client
+     * @var HttpClient
      */
     private $http_client = null;
 
@@ -114,7 +116,7 @@ class Api
      * @param string $api_endpoint       name of api selected
      * @param string $consumer_key       If you have already a consumer key, this parameter prevent to do a
      *                                   new authentication
-     * @param Client $http_client        instance of http client
+     * @param HttpClient $http_client        instance of http client
      *
      * @throws Exceptions\InvalidParameterException if one parameter is missing or with bad value
      */
@@ -123,7 +125,7 @@ class Api
         $application_secret,
         $api_endpoint,
         $consumer_key = null,
-        Client $http_client = null
+        HttpClient $http_client = null
     ) {
         if (!isset($application_key)) {
             throw new Exceptions\InvalidParameterException("Application key parameter is empty");
@@ -159,7 +161,7 @@ class Api
     /**
      * Calculate time delta between local machine and API's server
      *
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      * @return int
      */
     private function calculateTimeDelta()
@@ -186,7 +188,7 @@ class Api
      * @param string $redirection url to redirect on your website after authentication
      *
      * @return mixed
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     public function requestCredentials(
         array $accessRules,
@@ -221,7 +223,7 @@ class Api
      * @param bool                 $is_authenticated if the request use authentication
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     private function rawCall($method, $path, $content = null, $is_authenticated = true, $headers = null)
     {
@@ -309,7 +311,7 @@ class Api
      * @param array  $content content to send inside body of request
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     public function get($path, $content = null, $headers = null)
     {
@@ -325,7 +327,7 @@ class Api
      * @param array  $content content to send inside body of request
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     public function post($path, $content = null, $headers = null)
     {
@@ -341,7 +343,7 @@ class Api
      * @param array  $content content to send inside body of request
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     public function put($path, $content, $headers = null)
     {
@@ -357,7 +359,7 @@ class Api
      * @param array  $content content to send inside body of request
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\ClientException if http request is an error
+     * @throws \Http\Exception\TransferException if http request is an error
      */
     public function delete($path, $content = null, $headers = null)
     {

--- a/src/Api.php
+++ b/src/Api.php
@@ -143,13 +143,6 @@ class Api
             throw new Exceptions\InvalidParameterException("Unknown provided endpoint");
         }
 
-        if (!isset($http_client)) {
-            $http_client = new Client([
-                'timeout'         => 30,
-                'connect_timeout' => 5,
-            ]);
-        }
-
         $this->application_key    = $application_key;
         $this->endpoint           = $this->endpoints[$api_endpoint];
         $this->application_secret = $application_secret;

--- a/src/Api.php
+++ b/src/Api.php
@@ -37,6 +37,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
+use Http\Discovery\HttpClientDiscovery;
 
 /**
  * Wrapper to manage login and exchanges with simpliest Ovh API
@@ -254,8 +255,7 @@ class Api
         } elseif (isset($content)) {
             $body = json_encode($content);
         }
-        if(!is_array($headers))
-        {
+        if (!is_array($headers)) {
             $headers = [];
         }
         $headers['Content-Type']      = 'application/json; charset=utf-8';
@@ -378,6 +378,10 @@ class Api
      */
     public function getHttpClient()
     {
+        if ($this->http_client === null) {
+            $this->http_client = HttpClientDiscovery::find();
+        }
+
         return $this->http_client;
     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -365,6 +365,7 @@ class Api
 
     /**
      * Get the current consumer key
+     * @return string
      */
     public function getConsumerKey()
     {
@@ -373,6 +374,7 @@ class Api
 
     /**
      * Return instance of http client
+     * @return HttpClient
      */
     public function getHttpClient()
     {

--- a/tests/ApiFunctionalTest.php
+++ b/tests/ApiFunctionalTest.php
@@ -27,7 +27,7 @@
 
 namespace Ovh\tests;
 
-use GuzzleHttp\Client;
+use Http\Adapter\Guzzle6\Client;
 use Ovh\Api;
 
 /**
@@ -238,7 +238,7 @@ class ApiFunctionalTest extends \PHPUnit_Framework_TestCase
      */
     public function testApiGetWithParameters()
     {
-        $this->setExpectedException('\\GuzzleHttp\\Exception\\ClientException', '400');
+        $this->setExpectedException('Http\Client\Exception\HttpException', '400');
 
         $this->api->get('/me/accessRestriction/ip', ['foo' => 'bar']);
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -27,6 +27,7 @@
 
 namespace Ovh\tests;
 
+use Http\Adapter\Guzzle6\Client as HttpClient;
 use GuzzleHttp\Client;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
@@ -76,7 +77,8 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->consumer_key       = 'consumer';
         $this->endpoint           = 'ovh-eu';
 
-        $this->client = new Client();
+        $this->guzzle = new Client();
+        $this->client = new HttpClient($this->guzzle);
     }
 
     /**
@@ -152,9 +154,8 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testClientCreation()
     {
-        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key);
-
-        $this->assertInstanceOf('\\GuzzleHttp\\Client', $api->getHttpClient());
+        $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
+        $this->assertInstanceOf('Http\\Client\\HttpClient', $api->getHttpClient());
     }
 
     /**
@@ -164,7 +165,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $delay = 10;
 
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
             $body = $response->getBody();
@@ -191,7 +192,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testIfConsumerKeyIsReplace()
     {
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
             $body = $response->getBody();
@@ -221,10 +222,10 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     public function testInvalidApplicationKey()
     {
         $this->setExpectedException(
-            '\GuzzleHttp\Exception\ClientException'
+            'Http\Client\Exception\HttpException'
         );
 
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
             $body = $response->getBody();
@@ -254,10 +255,10 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     public function testInvalidRight()
     {
         $this->setExpectedException(
-            '\GuzzleHttp\Exception\ClientException'
+            'Http\Client\Exception\HttpException'
         );
 
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapResponse(function (Response $response) {
 
             $body = $response->getBody();
@@ -288,7 +289,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetQueryArgs()
     {
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapRequest(function (Request $request) {
             if($request->getUri()->getPath() == "/1.0/auth/time") {
                 return $request;
@@ -313,7 +314,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOverlappingQueryArgs()
     {
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapRequest(function (Request $request) {
             if($request->getUri()->getPath() == "/1.0/auth/time") {
                 return $request;
@@ -338,7 +339,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBooleanQueryArgs()
     {
-        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack = $this->guzzle->getConfig('handler');
         $handlerStack->push(Middleware::mapRequest(function (Request $request) {
             if($request->getUri()->getPath() == "/1.0/auth/time") {
                 return $request;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -118,7 +118,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingApplicationKey()
     {
-        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Application key');
+        $this->setExpectedException('Ovh\Exceptions\InvalidParameterException', 'Application key');
         new Api(null, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
     }
 
@@ -127,7 +127,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingApplicationSecret()
     {
-        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Application secret');
+        $this->setExpectedException('Ovh\Exceptions\InvalidParameterException', 'Application secret');
         new Api($this->application_key, null, $this->endpoint, $this->consumer_key, $this->client);
     }
 
@@ -136,7 +136,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingApiEndpoint()
     {
-        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Endpoint');
+        $this->setExpectedException('Ovh\Exceptions\InvalidParameterException', 'Endpoint');
         new Api($this->application_key, $this->application_secret, null, $this->consumer_key, $this->client);
     }
 
@@ -145,7 +145,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadApiEndpoint()
     {
-        $this->setExpectedException('\\Ovh\\Exceptions\\InvalidParameterException', 'Unknown');
+        $this->setExpectedException('Ovh\Exceptions\InvalidParameterException', 'Unknown');
         new Api($this->application_key, $this->application_secret, 'i_am_invalid', $this->consumer_key, $this->client);
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -303,9 +303,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
                 ->withQuery(''));
             return $request;
         }));
-        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
-        //    return $response;
-        //}));
 
         $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
         $api->get('/me/api/credential?applicationId=49', ['status' => 'pendingValidation']);
@@ -331,9 +328,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
                 ->withQuery(''));
             return $request;
         }));
-        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
-        //    return $response;
-        //}));
 
         $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
         $api->get('/me/api/credential?applicationId=49&status=pendingValidation', ['status' => 'expired', 'test' => "success"]);
@@ -359,9 +353,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
                 ->withQuery(''));
             return $request;
         }));
-        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
-        //    return $response;
-        //}));
 
         $api = new Api($this->application_key, $this->application_secret, $this->endpoint, $this->consumer_key, $this->client);
         $api->get('/me/api/credential', ['dryRun' => true, 'notDryRun' => false]);


### PR DESCRIPTION
We discussed in #34 about the fact that this library is fully coupled to Guzzle. I've worked on that PR to use the [php-http/httplug](https://github.com/php-http/httplug) interfaces which allow to decouple from any HTTP client.

In the dev dependencies I still require the [Guzzle6 adapter](https://github.com/php-http/guzzle6-adapter) to make all the tests passing.

With that update, it's possible to use the OVH API with all the Httplug adapters (ReactPHP, Socket, Curl, Guzzle5, Guzzle6, Buzz...).

All the projects which requires the OVH API must also require an adapter. It also allow to use the same HTTP client than in the project (just require the adapter).

I've also implemented the HttplugDiscovery plugin which allow to automatically resolve the currently available package through Puli. The only requirement is that the user include the [puli composer plugin](https://php-http.readthedocs.org/en/latest/discovery.html#installation).

If you have any questions about the implementation, just ask :smile:.

The library usage is the same as before, we can pass an `HttpClient` instance to the Api client or let the Discovery package resolve the current client.
