### PR TITLE
Escaping forward slashes leads to 400 response

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -256,7 +256,7 @@ class Api
             $request = $request->withUri($url);
             $body    = "";
         } elseif (isset($content)) {
-            $body = json_encode($content);
+            $body = json_encode($content, JSON_UNESCAPED_SLASHES);
 
             $request->getBody()->write($body);
         } else {


### PR DESCRIPTION
Hey, would be cool if you could take a look. I just started using the OVH API and I ran into an issue with escaped forward slashes in the JSON request body while using the endpoint `POST /cloud/project/{serviceName}/network/private/{networkId}/subnet`.

Result of the request is this:
```
PHP Fatal error:  Uncaught GuzzleHttp\Exception\ClientException: Client error: `POST https://api.ovh.com/1.0/cloud/project/[...]/network/private/[...]/subnet` resulted in a `400 InvalidArgument` response:
{"message":"Invalid JSON received"}
```
I checked what the request content looked like and found this (see value for *network*)
```
{"dhcp":true,"end":"10.0.0.254","network":"10.0.0.0\/24","noGateway":false,"region":"GRA1","start":"10.0.0.2"}
```
As soon as I deactivate escaping, the API accepts the request.