### PR TITLE
Make rawCall method protected instead of private

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -223,7 +223,7 @@ class Api
      * @return array
      * @throws \GuzzleHttp\Exception\ClientException if http request is an error
      */
-    private function rawCall($method, $path, $content = null, $is_authenticated = true, $headers = null)
+    protected function rawCall($method, $path, $content = null, $is_authenticated = true, $headers = null)
     {
         $url     = $this->endpoint . $path;
         $request = new Request($method, $url);


### PR DESCRIPTION
There is no point keeping the rawCall method private. On the other hand, the rawCall method being protected makes it easier to extend \Ovh\Api class.

Use case : I extend \Ovh\Api class and want to override get, post, put and delete methods to manipulate $content param before making a request. I cannot do this now because i cannot call private rawCall method from a child class. I can provide a quick explanation snippet if needed.

Signed-off-by: Hedi Chaibi contact@hedichaibi.com