### PR TITLE
Allow URL for api_endpoint specification

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -137,8 +137,19 @@ class Api
             throw new Exceptions\InvalidParameterException("Endpoint parameter is empty");
         }
 
-        if (!array_key_exists($api_endpoint, $this->endpoints)) {
-            throw new Exceptions\InvalidParameterException("Unknown provided endpoint");
+        if (preg_match('/^https?:\/\/..*/',$api_endpoint))
+        {
+          $this->endpoint         = $api_endpoint;
+        }
+        else
+        {
+          if (!array_key_exists($api_endpoint, $this->endpoints)) {
+              throw new Exceptions\InvalidParameterException("Unknown provided endpoint");
+          }
+          else
+          {
+            $this->endpoint       = $this->endpoints[$api_endpoint];
+          }
         }
 
         if (!isset($http_client)) {
@@ -149,7 +160,6 @@ class Api
         }
 
         $this->application_key    = $application_key;
-        $this->endpoint           = $this->endpoints[$api_endpoint];
         $this->application_secret = $application_secret;
         $this->http_client        = $http_client;
         $this->consumer_key       = $consumer_key;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -367,4 +367,106 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $api->get('/me/api/credential', ['dryRun' => true, 'notDryRun' => false]);
     }
 
+    /**
+     * Test valid predefined endpoint
+     */
+    public function testPredefinedEndPoint()
+    {
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapRequest(function (Request $request) {
+            if($request->getUri()->getPath() == "/1.0/auth/time") {
+                return $request;
+            }
+
+            $host = $request->getUri()->getHost();
+            $this->assertEquals($host, 'ca.api.ovh.com');
+
+            $resource = $request->getUri()->getPath();
+            $this->assertEquals($resource, '/1.0/me/api/credential');
+
+            $resource = $request->getUri()->getScheme();
+            $this->assertEquals($resource, 'https');
+
+            $request = $request->withUri($request->getUri()
+                ->withHost('httpbin.org')
+                ->withPath('/')
+                ->withQuery(''));
+            return $request;
+        }));
+        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
+        //    return $response;
+        //}));
+
+        $api = new Api($this->application_key, $this->application_secret, 'ovh-ca', $this->consumer_key, $this->client);
+        $api->get('/me/api/credential');
+    }
+
+    /**
+     * Test valid provided HTTP endpoint
+     */
+    public function testProvidedHttpEndPoint()
+    {
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapRequest(function (Request $request) {
+            if($request->getUri()->getPath() == "/1.0/auth/time") {
+                return $request;
+            }
+
+            $host = $request->getUri()->getHost();
+            $this->assertEquals($host, 'api.ovh.com');
+
+            $resource = $request->getUri()->getPath();
+            $this->assertEquals($resource, '/1.0/me/api/credential');
+
+            $resource = $request->getUri()->getScheme();
+            $this->assertEquals($resource, 'http');
+
+            $request = $request->withUri($request->getUri()
+                ->withHost('httpbin.org')
+                ->withPath('/')
+                ->withQuery(''));
+            return $request;
+        }));
+        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
+        //    return $response;
+        //}));
+
+        $api = new Api($this->application_key, $this->application_secret, 'http://api.ovh.com/1.0', $this->consumer_key, $this->client);
+        $api->get('/me/api/credential');
+    }
+
+    /**
+     * Test valid provided HTTPS endpoint
+     */
+    public function testProvidedHttpsEndPoint()
+    {
+        $handlerStack = $this->client->getConfig('handler');
+        $handlerStack->push(Middleware::mapRequest(function (Request $request) {
+            if($request->getUri()->getPath() == "/1.0/auth/time") {
+                return $request;
+            }
+
+            $host = $request->getUri()->getHost();
+            $this->assertEquals($host, 'api.ovh.com');
+
+            $resource = $request->getUri()->getPath();
+            $this->assertEquals($resource, '/1.0/me/api/credential');
+
+            $resource = $request->getUri()->getScheme();
+            $this->assertEquals($resource, 'https');
+
+            $request = $request->withUri($request->getUri()
+                ->withHost('httpbin.org')
+                ->withPath('/')
+                ->withQuery(''));
+            return $request;
+        }));
+        //$handlerStack->push(Middleware::mapResponse(function (Response $response) {
+        //    return $response;
+        //}));
+
+        $api = new Api($this->application_key, $this->application_secret, 'https://api.ovh.com/1.0', $this->consumer_key, $this->client);
+        $api->get('/me/api/credential');
+    }
+
 }


### PR DESCRIPTION
The api_endpoint can accept URL, if the api_endpoint seems to be a http/https URL, it will used directly, if not the previous behaviour is used.

Signed-off-by: Marc Carmier mcarmier@gmail.com