### PR TITLE
Travis : Removing hhvm, PHP 5.5 and adding PHP 7.1, 7.2, 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ addons:
 
 language: php
 php:
-  - hhvm
   - 7.0
   - 5.6
-  - 5.5
-  - 7.0
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ addons:
 
 language: php
 php:
+  - 7.3
+  - 7.2
+  - 7.1
   - 7.0
   - 5.6
 


### PR DESCRIPTION
These two versions are not available anymore on ubuntu xenial so builds are failing.
Signed-off-by: Germain Carré <germaincarre@yahoo.fr>