### PR TITLE
Tests for php 7.4 and stop testing EOL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ addons:
 
 language: php
 php:
+  - 7.4
   - 7.3
   - 7.2
-  - 7.1
-  - 7.0
-  - 5.6
 
 before_script:
   - composer self-update


### PR DESCRIPTION
According to https://www.php.net/supported-versions.php , php versions older than 7.2 are EOL. We can drop them from tests and add 7.4 which is the currently supported version of PHP.