### PR TITLE
Switching Guzzle build_query to Query::build & Adding PHP 8.x in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ addons:
     - libcurl4-openssl-dev
 
 language: php
+dist: focal
 php:
+  - 8.1.0
+  - 8.0
   - 7.4
 
 before_script:

--- a/src/Api.php
+++ b/src/Api.php
@@ -263,7 +263,7 @@ class Api
                 }
             }
 
-            $query = \GuzzleHttp\Psr7\build_query($query);
+            $query = \GuzzleHttp\Psr7\Query::build($query);
 
             $url     = $request->getUri()->withQuery($query);
             $request = $request->withUri($url);


### PR DESCRIPTION
After Guzzle 7.2, GuzzleHttp\Psr7\build_query has been replaced by GuzzleHttp\Psr7\Query::build
cf https://github.com/guzzle/guzzle/pull/2712 & https://github.com/guzzle/psr7/pull/345

Also adding PHP 8.0 & 8.1 in travis build