### PR TITLE
Add missing "clone" in tests instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ How to run tests?
 Tests are based on phpunit. To install it with other quality tools, you can install
 local npm project in a clone a project
 
-    git https://github.com/ovh/php-ovh.git
+    git clone https://github.com/ovh/php-ovh.git
     cd php-ovh
     php composer.phar install
 


### PR DESCRIPTION
Hi,
This is just a small fix in the "How to run tests?" section.
The git command instruction is missing ;-)