### PR TITLE
Replace long array syntax with short syntax

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -261,7 +261,7 @@ class Api
         if (isset($content) && $method === 'GET') {
             $query_string = $request->getUri()->getQuery();
 
-            $query = array();
+            $query = [];
             if (!empty($query_string)) {
                 $queries = explode('&', $query_string);
                 foreach ($queries as $element) {


### PR DESCRIPTION
# Changed log

- It should be good to use the short array syntax to replace the long array syntax.