### PR TITLE
Apply string to class constant

### DIFF
--- a/tests/ApiFunctionalTest.php
+++ b/tests/ApiFunctionalTest.php
@@ -119,7 +119,7 @@ class ApiFunctionalTest extends TestCase
      */
     protected static function getPrivateMethod($name)
     {
-        $class  = new \ReflectionClass('Ovh\Api');
+        $class  = new \ReflectionClass(\Ovh\Api::class);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
 
@@ -135,7 +135,7 @@ class ApiFunctionalTest extends TestCase
      */
     protected static function getPrivateProperty($name)
     {
-        $class    = new \ReflectionClass('Ovh\Api');
+        $class    = new \ReflectionClass(\Ovh\Api::class);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -79,7 +79,7 @@ class ApiTest extends TestCase
      */
     protected static function getPrivateProperty($name)
     {
-        $class    = new \ReflectionClass('Ovh\Api');
+        $class    = new \ReflectionClass(\Ovh\Api::class);
         $property = $class->getProperty($name);
         $property->setAccessible(true);
 


### PR DESCRIPTION
# Changed log

- Using the string class constant approach to replace the string class name.