### PR TITLE
fix(Api.php) : handle 204 no content response in decodeResponse

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -329,6 +329,10 @@ class Api
      */
     private function decodeResponse(Response $response)
     {
+        if ($response->getStatusCode() === 204 || $response->getBody()->getSize() === 0) {
+            return [];
+        }
+
         return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
     }
 


### PR DESCRIPTION
### Context:  
Ovh api now send a 204 no content response when you call /domain/zone/{zoneName}/refresh endpoint.

### Problem: 
Api.php\decodeResponse method throw a error by default when it fail to decode json, and so when you pass empty string from no content reponse

### Proposal:
ruturn empty array when response has code 204 or body length is 0

All tests are passing, hope this can be merged fast.

Thanks !